### PR TITLE
Add remote_src parameter to enable copying file within remote host

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ This roles is test on the following GNU/Linux distributions.
 The data can be in variables or a list (array). When a list is used, the role
 will loop over the list and create all defined QEMU disk images.
 
-  * **dest**: required  The destination image
-  * **src**:  optional  The source image, a new image will be created if not defined. 
-  * **size**: optional, required if no src is defined. The size of the destination image.
-  * **owner**: uid default 0  The file owner of the destination image
-  * **group**: gid default 0  The file group of the destination image 
-  * **mode**:  mode default '0400'  The permissions of the destination image
+  * **dest**: required. The destination image.
+  * **src**: optional. The source image, a new image will be created if not defined.
+  * **size**: optional. required if no src is defined. The size of the destination image.
+  * **owner**: uid, default 0. The file owner of the destination image.
+  * **group**: gid, default 0. The file group of the destination image.
+  * **mode**: mode, default '0400'. The permissions of the destination image.
   * **remote_src**: boolean, default: false. When the source file is in remote host.
-  * **format**: format default: qcow2 The disk image format.
-  * **overwrite**: boolean default: false Overwrite destination if already exists.
+  * **format**: format, default: qcow2. The disk image format.
+  * **overwrite**: boolean, default: false. Overwrite destination if already exists.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ will loop over the list and create all defined QEMU disk images.
   * **owner**: uid default 0  The file owner of the destination image
   * **group**: gid default 0  The file group of the destination image 
   * **mode**:  mode default '0400'  The permissions of the destination image
+  * **remote_src**: boolean, default: false. When the source file is in remote host.
   * **format**: format default: qcow2 The disk image format.
   * **overwrite**: boolean default: false Overwrite destination if already exists.
 

--- a/tasks/qemu_image.yml
+++ b/tasks/qemu_image.yml
@@ -37,6 +37,7 @@
         owner: "{{ _qemu_image.owner | default(0) }}"
         group: "{{ _qemu_image.group | default(0) }}"
         mode:  "{{ _qemu_image.mode | default('0500') }}"
+        remote_src:  "{{ _qemu_image.remote_src | default('false') }}"
 
     - name: set _qemu_img_cmd to size the image
       set_fact:


### PR DESCRIPTION
The current copy module only allows copying image files from local to remote host. With `remote_src` enabled, we should be able to copy the file that are already in remote host.