### PR TITLE
6 execute installation tasks only once

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,11 @@
 - name: Install qemu img
   ansible.builtin.include_tasks:
     install.yml
+#
+# Set run_once to allow the role to be executed in parallel
+# e.g. when delegate_to in used.
+#
+  run_once: true
   args:
     apply:
       tags:

--- a/tasks/qemu_image.yml
+++ b/tasks/qemu_image.yml
@@ -38,8 +38,8 @@
         dest: "{{ _qemu_image.dest }}"
         owner: "{{ _qemu_image.owner | default(0) }}"
         group: "{{ _qemu_image.group | default(0) }}"
-        mode:  "{{ _qemu_image.mode | default('0500') }}"
-        remote_src:  "{{ _qemu_image.remote_src | default('false') }}"
+        mode: "{{ _qemu_image.mode | default('0500') }}"
+        remote_src: "{{ _qemu_image.remote_src | default('false') }}"
 
     - name: Set _qemu_img_cmd to size the image
       ansible.builtin.set_fact:


### PR DESCRIPTION
* Execute installation tasks only once to allow parallel execution of roles on the same host e.g. With delegate_to